### PR TITLE
Changed link for GAE SDK download

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -8,7 +8,7 @@ The trace files can be uploaded manually, or via a GitHub Webhook. The results a
 
 The backend uses Python and Google App Engine (a node version is in the works).
 
-1. Download the [Google Cloud SDK](https://cloud.google.com/sdk/).
+1. Download the [Google Cloud SDK for Python](https://cloud.google.com/appengine/downloads).
 2. Clone the repo.
 3. `npm install`.
 4. `gulp` (or `gulp dev` if you plan to change code).

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigrig-webapp",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "private": true,
   "engines": {
     "node": ">=5.0.0"


### PR DESCRIPTION
Changed the URL and linktext for the GAE SDK download link. I followed the instructions and downloaded and installed the SDK from the original link, but that installs only the SDK and not the Launcher (GUI). Trying to follow the instructions with that version or flavour of the SDK is impossible.