### PR TITLE
Modify selenium web driver version to be fixed

### DIFF
--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -24,7 +24,7 @@
   "author": "Paul Lewis",
   "license": "Apache-2.0",
   "dependencies": {
-    "selenium-webdriver": "^2.48.0",
+    "selenium-webdriver": "2.48.0",
     "yargs": "^3.29.0"
   },
   "repository": {


### PR DESCRIPTION
In the newer version of Selenium Webdriver, `Logs` is no longer a function of the `WebDriver` module. This would be a quick fix to set the version, however I think a more robust fix would be needed in the future. 

Error:
![image](https://cloud.githubusercontent.com/assets/6798667/16253971/8f26a5a4-388f-11e6-8335-14edd44f1917.png)

Here's an issue in another project where someone had the same problem: https://github.com/tastejs/todomvc/issues/1605
